### PR TITLE
Pointing out runtime type error in Stock.scala

### DIFF
--- a/src/main/scala/paths/high/Stock.scala
+++ b/src/main/scala/paths/high/Stock.scala
@@ -40,7 +40,7 @@ object StockNative extends js.Object {
 trait StockCurve[A] extends js.Object {
   val line: Polygon = js.native
   val area: Polygon = js.native
-  val item: A = js.native
+  val item: js.Array[A] = js.native
   val index: Int = js.native
 }
 


### PR DESCRIPTION
This seems to be a collection of items. Even if it were actually a single item, it does not  make sense which specific item this should refer to, since the points in a Stock Curve are dependent on a collection of items.
