### PR TITLE
cross compile for scala 2.11 and scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .classpath
 .project
 .settings/
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The demo application is still incomplete, and fails to show many of Paths.scala.
 Usage
 -----
 
-Paths.scala.js is published for Scala 2.11 with Scala.js 0.6. In a Scala.js project, you can depend on Paths.scala.js with
+Paths.scala.js is published for Scala 2.11 and Scala 2.12 with Scala.js 0.6. In a Scala.js project, you can depend on Paths.scala.js with
 
-    libraryDependencies += "eu.unicredit" %%% "paths-scala-js" % "0.4.4"
+    libraryDependencies += "eu.unicredit" %%% "paths-scala-js" % "0.4.5"
 
 Compatibility
 -------------

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,3 @@
-import SonatypeKeys._
-
-sonatypeSettings
-
 // Turn this project into a Scala.js project by importing these settings
 enablePlugins(ScalaJSPlugin)
 
@@ -11,11 +7,13 @@ name := "paths-scala-js"
 
 version := "0.4.5"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.4"
 
-persistLauncher in Compile := true
+crossScalaVersions := Seq("2.11.7", "2.12.4")
 
-persistLauncher in Test := false
+scalaJSUseMainModuleInitializer in Compile := true
+
+scalaJSUseMainModuleInitializer in Test := false
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.17

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")


### PR DESCRIPTION
Cross compile for scala 2.11 and scala 2.12 instead of building only for scala 2.11.
For that I needed to upgrade to scala-js 0.6.22 and fix some deprecations.

You should now publish in sbt with `+ publish` instead of `publish`, as with all [cross-compiled projects](https://blog.ssanj.net/posts/2017-06-26-crosscompile-multiple-versions-of-scala-via-sbt.html).